### PR TITLE
Bump some dependencies

### DIFF
--- a/lib/src/components/app/app.dart
+++ b/lib/src/components/app/app.dart
@@ -18,8 +18,9 @@ import '../../state/app.dart';
 @Component(
     selector: 'app',
     templateUrl: 'app.html',
-    directives: const [ROUTER_DIRECTIVES, CategoryCreateModalComponent, ItemCreateModalComponent, ManageContentModalComponent, ConfirmShredModalComponent],
-    providers: const [StoreService])
+    directives: const [ ROUTER_DIRECTIVES, CategoryCreateModalComponent, ItemCreateModalComponent, ManageContentModalComponent, ConfirmShredModalComponent],
+    providers: const [StoreService]
+)
 @RouteConfig(const [
   const Route(
     path: '/home',

--- a/lib/src/middleware/creationMiddleware.dart
+++ b/lib/src/middleware/creationMiddleware.dart
@@ -66,7 +66,7 @@ class CreateNotePayload {
 ///////////////////
 
 createCreationMiddleware(FirebaseClient client) =>
-    (new MiddlwareBuilder<App, AppBuilder, AppActions>()
+    (new MiddlewareBuilder<App, AppBuilder, AppActions>()
           ..add<CreateBoardPayload>(CreationMiddlewareActionsNames.board, _createBoard(client))
           ..add<CreateSessionPayload>(
               CreationMiddlewareActionsNames.session, _createSession(client))

--- a/lib/src/middleware/refMiddleware.dart
+++ b/lib/src/middleware/refMiddleware.dart
@@ -18,7 +18,7 @@ import '../models/item.dart';
 /// Action Map
 ///////////////////
 
-createRefMiddleware(FirebaseClient client) => (new MiddlwareBuilder<App, AppBuilder, AppActions>()
+createRefMiddleware(FirebaseClient client) => (new MiddlewareBuilder<App, AppBuilder, AppActions>()
       ..add<String>(CategoriesActionsNames.hide, _hideCategory(client))
       ..add<String>(CategoriesActionsNames.show, _showCategory(client))
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,19 +6,19 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.29.11"
+    version: "0.30.0+4"
   angular2:
     description:
       name: angular2
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0+1"
   angular_test:
     description:
       name: angular_test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-beta+2"
+    version: "1.0.0-beta+3"
   ansicolor:
     description:
       name: ansicolor
@@ -30,7 +30,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.29"
+    version: "1.0.31"
   args:
     description:
       name: args
@@ -48,7 +48,7 @@ packages:
       name: barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+11"
+    version: "0.15.2+12"
   boolean_selector:
     description:
       name: boolean_selector
@@ -66,43 +66,43 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "0.9.3"
   build_barback:
     description:
       name: build_barback
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.2.2"
   build_runner:
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.3.4+1"
   built_collection:
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   built_redux:
     description:
       name: built_redux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "2.1.2"
   built_value:
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.1"
   built_value_generator:
     description:
       name: built_value_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.2.1"
   charcode:
     description:
       name: charcode
@@ -114,7 +114,13 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+2"
+    version: "0.1.2+1"
+  code_builder:
+    description:
+      name: code_builder
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   code_transformers:
     description:
       name: code_transformers
@@ -126,7 +132,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.1"
+    version: "1.14.3"
   convert:
     description:
       name: convert
@@ -138,7 +144,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2+1"
   csslib:
     description:
       name: csslib
@@ -150,25 +156,31 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.8"
   dart_to_js_script_rewriter:
     description:
       name: dart_to_js_script_rewriter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   firebase:
     description:
       name: firebase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.0"
   fixnum:
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.5"
+    version: "0.10.6"
+  front_end:
+    description:
+      name: front_end
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0-alpha.4.1"
   func:
     description:
       name: func
@@ -180,7 +192,7 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   html:
     description:
       name: html
@@ -192,13 +204,13 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+13"
+    version: "0.11.3+15"
   http_multi_server:
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   http_parser:
     description:
       name: http_parser
@@ -210,19 +222,25 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.0"
+    version: "0.15.1"
   isolate:
     description:
       name: isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   js:
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.1"
+  kernel:
+    description:
+      name: kernel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0-alpha.1.1"
   logging:
     description:
       name: logging
@@ -234,13 +252,13 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1+1"
+    version: "0.12.1+4"
   meta:
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.2"
   mime:
     description:
       name: mime
@@ -252,13 +270,19 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.2.0"
+  node_preamble:
+    description:
+      name: node_preamble
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
   package_config:
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   package_resolver:
     description:
       name: package_resolver
@@ -282,19 +306,19 @@ packages:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.0+2"
   pool:
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   protobuf:
     description:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.4"
+    version: "0.5.5"
   pub_semver:
     description:
       name: pub_semver
@@ -312,31 +336,31 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.7+2"
+    version: "0.6.8"
   shelf_packages_handler:
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   shelf_static:
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.4"
+    version: "0.2.5"
   shelf_web_socket:
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   source_gen:
     description:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.5"
+    version: "0.5.10+1"
   source_map_stack_trace:
     description:
       name: source_map_stack_trace
@@ -360,13 +384,19 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.3"
+    version: "1.8.2"
   stream_channel:
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
+  stream_transform:
+    description:
+      name: stream_transform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.9"
   string_scanner:
     description:
       name: string_scanner
@@ -384,13 +414,13 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.21"
+    version: "0.12.24+8"
   typed_data:
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.5"
   unittest:
     description:
       name: unittest
@@ -408,36 +438,24 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+3"
+    version: "0.9.7+4"
   web_socket_channel:
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.6"
   webdriver:
     description:
       name: webdriver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.3"
-  when:
-    description:
-      name: when
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.0"
-  which:
-    description:
-      name: which
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
   yaml:
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.13"
 sdks:
-  dart: ">=1.23.0 <2.0.0"
+  dart: ">=1.24.0 <2.0.0-dev.infinity"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: '>=1.23.0 <2.0.0'
 dependencies:
   angular2: ^3.0.0
-  built_redux: ^1.0.0
+  built_redux: ^2.0.0
   firebase: '^3.0.0'
   intl: '^0.15.0'
 
@@ -16,7 +16,7 @@ dev_dependencies:
   mockito: ^2.0.2
   test: ^0.12.0
   built_collection: ^1.3.0
-  build: ^0.7.0
+  build: ^0.9.0
   build_runner: ^0.3.0
   built_value_generator: ^1.0.0
 


### PR DESCRIPTION
Hey @davidmarne I was going to migrate the project to angular 4, but it would require updates to the following packages:
* built_redux
* build
* built_value_generator
* source_gen
* build_runner

The latter two would have broken functionality in build.dart and watcher.dart that I wouldn't know how to fully resolve since GeneratorBuilder is replaced by LibraryBuilder and PartBuilder depending on needs.

So I bumped the dependencies to what I could and updated the code where it seemed changes were needed. Hopefully, this is helpful.

I was tempted to remove the test packages since they are not used, but left them in there. I'll likely look at the issues you have later.