### PR TITLE
Autofocus the item and topic creation textareas

### DIFF
--- a/lib/src/components/categoryCreateModal/categoryCreateModal.dart
+++ b/lib/src/components/categoryCreateModal/categoryCreateModal.dart
@@ -1,3 +1,5 @@
+import 'dart:html';
+
 import 'package:angular/angular.dart';
 import 'package:angular_forms/angular_forms.dart';
 import 'package:built_redux/built_redux.dart';
@@ -14,7 +16,7 @@ import '../../middleware/creationMiddleware.dart';
       COMMON_DIRECTIVES,
       formDirectives,
     ])
-class CategoryCreateModalComponent {
+class CategoryCreateModalComponent implements OnInit {
   final Store<App, AppBuilder, AppActions> _store;
 
   CategoryCreateModalComponent(StoreService storeService)
@@ -27,6 +29,10 @@ class CategoryCreateModalComponent {
   String selectedColor = CAT_COLOR_DEFAULT;
 
   List<String> colors = CAT_COLORS;
+
+  void ngOnInit() {
+    querySelector('.is-autofocused').focus();
+  }
 
   String colorLabel(String color) => catColorDescription(color);
 

--- a/lib/src/components/categoryCreateModal/categoryCreateModal.html
+++ b/lib/src/components/categoryCreateModal/categoryCreateModal.html
@@ -7,7 +7,7 @@
     <div class="field">
       <label class="label">Title</label>
       <p class="control">
-        <input [(ngModel)]="title" class="input" type="text" placeholder="Set a theme...">
+        <input [(ngModel)]="title" class="input is-autofocused" type="text" placeholder="Set a theme...">
       </p>
     </div>
 

--- a/lib/src/components/itemCreateModal/itemCreateModal.dart
+++ b/lib/src/components/itemCreateModal/itemCreateModal.dart
@@ -1,3 +1,5 @@
+import 'dart:html';
+
 import 'package:angular/angular.dart';
 import 'package:angular_forms/angular_forms.dart';
 import 'package:built_redux/built_redux.dart';
@@ -14,7 +16,7 @@ import '../../middleware/creationMiddleware.dart';
       COMMON_DIRECTIVES,
       formDirectives,
     ])
-class ItemCreateModalComponent {
+class ItemCreateModalComponent implements OnInit {
   final Store<App, AppBuilder, AppActions> _store;
 
   ItemCreateModalComponent(StoreService storeService)
@@ -27,6 +29,10 @@ class ItemCreateModalComponent {
   bool isPoll = false;
 
   List<String> options = [];
+
+  void ngOnInit() {
+    querySelector('.is-autofocused').focus();
+  }
 
   void addItem() {
     _store.actions.creation.item(

--- a/lib/src/components/itemCreateModal/itemCreateModal.html
+++ b/lib/src/components/itemCreateModal/itemCreateModal.html
@@ -6,7 +6,7 @@
   <section class="modal-card-body">
     <div class="field">
       <p class="control">
-        <textarea [(ngModel)]="description" class="textarea" placeholder="Let it out"></textarea>
+        <textarea [(ngModel)]="description" class="textarea is-autofocused" placeholder="Let it out" ></textarea>
       </p>
     </div>
 
@@ -39,7 +39,7 @@
         </div>
       </div>
     </div>
-    
+
     <div class="field is-horizontal">
       <div class="field-body">
         <div class="field is-grouped">


### PR DESCRIPTION
Creating a topic or an item was slightly annoying, since textareas were not focused by default.  Now, the textareas are focused onInit!  I tried doing this using the normal css `autofocus` class, but that only works for the first new item created, and not the subsequent creations.  This works every time the modals open.