### PR TITLE
Add word-wrapping to retro board cards

### DIFF
--- a/web/retro.css
+++ b/web/retro.css
@@ -1,33 +1,50 @@
 @media (max-width: 768px) {
   .modal-card {
-    -webkit-mask-image: -webkit-linear-gradient(45deg, black 0%, black 90%, rgba(0, 0, 0, 0.3) 90%, rgba(0, 0, 0, 0.3) 100%); }
-  .modal-content {
-    -webkit-mask-image: -webkit-linear-gradient(45deg, black 0%, black 90%, rgba(0, 0, 0, 0.3) 90%, rgba(0, 0, 0, 0.3) 100%); } }
+    -webkit-mask-image: -webkit-linear-gradient(45deg, black 0%, black 90%, rgba(0, 0, 0, 0.3) 90%, rgba(0, 0, 0, 0.3) 100%);
+  }
 
+  .modal-content {
+    -webkit-mask-image: -webkit-linear-gradient(45deg, black 0%, black 90%, rgba(0, 0, 0, 0.3) 90%, rgba(0, 0, 0, 0.3) 100%);
+  }
+}
 .modal-card {
   max-height: 100vh;
-  padding: 20px 0; }
+  padding: 20px 0;
+}
 
 .modal-content {
   max-height: 100vh;
-  padding: 20px 0; }
+  padding: 20px 0;
+}
 
 .reduced-vertical-padding {
   padding-top: 1rem;
-  padding-bottom: 1rem; }
+  padding-bottom: 1rem;
+}
 
 .pointer-hand {
-  cursor: pointer; }
+  cursor: pointer;
+}
 
 .covered {
-  opacity: 0.5; }
+  opacity: 0.5;
+}
 
 .is-extra-small {
-  height: 2px; }
+  height: 2px;
+}
 
 .option-result {
   display: inline-block;
-  width: 3rem; }
+  width: 3rem;
+}
 
 .fa-check-square-o {
-  transform: translate3d(0.1rem, 0, 0); }
+  transform: translate3d(0.1rem, 0, 0);
+}
+
+.notification {
+  word-wrap: break-word;
+}
+
+/*# sourceMappingURL=retro.css.map */

--- a/web/retro.css.map
+++ b/web/retro.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sourceRoot":"","sources":["sass/_modal.scss","sass/retro.scss"],"names":[],"mappings":"AAAA;EACE;IACE;;;EAGF;IACE;;;AAIJ;EACE;EACA;;;AAGF;EACE;EACA;;;ACfF;EACE;EACA;;;AAGF;EACE;;;AAGF;EACE;;;AAGF;EACE;;;AAGF;EACE;EACA;;;AAGF;EACE;;;AAIF;EACE","file":"retro.css"}

--- a/web/sass/retro.scss
+++ b/web/sass/retro.scss
@@ -25,3 +25,8 @@
 .fa-check-square-o {
   transform: translate3d(0.1rem, 0, 0);
 }
+
+// Adding word-wrap to bulma's notification class
+.notification {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Currently long strings with no spaces (such as links) will overflow outside of it's card, for example:
![image](https://user-images.githubusercontent.com/29549404/48778759-0f487a80-eca4-11e8-8e4c-c4248601adfb.png)

I added `word-wrap: break-word;` to Bulma's `.notification` class which solves this issue:
<img width="423" alt="image" src="https://user-images.githubusercontent.com/29549404/48778803-22f3e100-eca4-11e8-9e84-654890eb8559.png">

To regenerate the CSS I ran `sass sass/retro.scss retro.css` inside the `web/` folder.  This did quite a few edits to the existing CSS file, mostly with the placement of brackets so let me know if thats a problem.  Also I committed the source mapping file, let me know if I should get rid of that.